### PR TITLE
内聚C模块

### DIFF
--- a/ecs_group.c
+++ b/ecs_group.c
@@ -307,3 +307,17 @@ ecs_group_enable(lua_State *L) {
 	}
 	return 0;
 }
+
+int
+lgroup_methods(lua_State *L) { 
+		luaL_Reg m[] = {
+		{ "_group_update", ecs_group_update },
+		{ "_group_fetch", ecs_group_fetch },
+		{ "_group_enable", ecs_group_enable },
+		{ "_group_id", ecs_group_id },
+		{ NULL, NULL },
+	};
+	luaL_newlib(L, m);
+
+	return 1;
+}

--- a/ecs_group.h
+++ b/ecs_group.h
@@ -3,9 +3,6 @@
 
 #include <lua.h>
 
-int ecs_group_update(lua_State *L);
-int ecs_group_id(lua_State *L);
-int ecs_group_fetch(lua_State *L);
-int ecs_group_enable(lua_State *L);
+int lgroup_methods(lua_State *L);
 
 #endif

--- a/ecs_index.c
+++ b/ecs_index.c
@@ -292,3 +292,16 @@ ecs_index_make(lua_State *L) {
 	lua_setmetatable(L, -2);
 	return 1;
 }
+
+int
+lindex_methods(lua_State *L) {
+	luaL_Reg m[] = {
+		{ "_cache_index", ecs_index_cache },
+		{ "_access_index", ecs_index_access },
+		{ "_make_index", ecs_index_make },
+		{ NULL, NULL },
+	};
+	luaL_newlib(L, m);
+
+	return 1;
+}

--- a/ecs_index.h
+++ b/ecs_index.h
@@ -3,8 +3,6 @@
 
 #include <lua.h>
 
-int ecs_index_cache(lua_State *L);
-int ecs_index_access(lua_State *L);
-int ecs_index_make(lua_State *L);
+int lindex_methods(lua_State *L);
 
 #endif

--- a/ecs_persistence.c
+++ b/ecs_persistence.c
@@ -270,3 +270,17 @@ ecs_persistence_resetmaxid(lua_State *L) {
 	w->max_id = 0;
 	return 0;
 }
+
+int
+lpersistence_methods(lua_State *L) {
+	luaL_Reg m[] = {
+		{ "_readcomponent", ecs_persistence_readcomponent },
+		{ "_resetmaxid", ecs_persistence_resetmaxid },
+		{ "writer", ecs_persistence_writer },
+		{ "reader", ecs_persistence_reader },		
+		{ NULL, NULL },
+	};
+	luaL_newlib(L, m);
+
+	return 1;
+}

--- a/ecs_persistence.h
+++ b/ecs_persistence.h
@@ -3,9 +3,6 @@
 
 #include <lua.h>
 
-int ecs_persistence_readcomponent(lua_State *L);
-int ecs_persistence_writer(lua_State *L);
-int ecs_persistence_reader(lua_State *L);
-int ecs_persistence_resetmaxid(lua_State *L);
+int lpersistence_methods(lua_State *L);
 
 #endif

--- a/ecs_template.c
+++ b/ecs_template.c
@@ -207,3 +207,19 @@ ecs_serialize_lua(lua_State *L) {
 	luaL_pushresult(&b);
 	return 1;
 }
+
+
+int
+ltemplate_methods(lua_State *L) {
+	luaL_Reg m[] = {
+		{ "_serialize", ecs_serialize_object },
+		{ "_serialize_lua", ecs_serialize_lua },
+		{ "_template_extract", ecs_template_extract },
+		{ "_template_create", ecs_template_create },
+		{ "_template_instance_component", ecs_template_instance_component },
+		{ NULL, NULL },
+	};
+	luaL_newlib(L, m);
+
+	return 1;
+}

--- a/ecs_template.h
+++ b/ecs_template.h
@@ -3,10 +3,6 @@
 
 #include <lua.h>
 
-int ecs_serialize_object(lua_State *L);
-int ecs_serialize_lua(lua_State *L);
-int ecs_template_create(lua_State *L);
-int ecs_template_extract(lua_State *L);
-int ecs_template_instance_component(lua_State *L);
+int ltemplate_methods(lua_State *L);
 
 #endif

--- a/luaecs.c
+++ b/luaecs.c
@@ -1589,18 +1589,6 @@ lmethods(lua_State *L) {
 		{ "_read", lread },
 		{ "_dumpid", ldumpid },
 		{ "_readid", lreadid },
-		{ "_make_index", ecs_index_make },
-		{ "_readcomponent", ecs_persistence_readcomponent },
-		{ "_resetmaxid", ecs_persistence_resetmaxid },
-		{ "_group_update", ecs_group_update },
-		{ "_group_fetch", ecs_group_fetch },
-		{ "_group_enable", ecs_group_enable },
-		{ "_group_id", ecs_group_id },
-		{ "_serialize", ecs_serialize_object },
-		{ "_serialize_lua", ecs_serialize_lua },
-		{ "_template_extract", ecs_template_extract },
-		{ "_template_create", ecs_template_create },
-		{ "_template_instance_component", ecs_template_instance_component },
 		{ "_count", lcount },
 		{ "_clone", lclone },
 		{ "_clone_blacklist", lclone_blacklist },
@@ -1618,11 +1606,13 @@ luaopen_ecs_core(lua_State *L) {
 	luaL_Reg l[] = {
 		{ "_world", lnew_world },
 		{ "_methods", lmethods },
-		{ "_cache_index", ecs_index_cache },
-		{ "_access_index", ecs_index_access },
-		{ "writer", ecs_persistence_writer },
-		{ "reader", ecs_persistence_reader },
 		{ "check_select", lcheck_iter },
+		
+		/*library extension*/
+		{ "_group_methods", lgroup_methods },
+		{ "_index_methods", lindex_methods },
+		{ "_persistence_methods", lpersistence_methods },
+		{ "_template_methods", ltemplate_methods },
 		{ NULL, NULL },
 	};
 	luaL_newlib(L, l);


### PR DESCRIPTION
template, group, index等是ecs核心库的扩展, 通过各自导出lua方法, 增强模块的内聚性.

担心lua api的兼容问题, 所以lua侧没有调整接口