### PR TITLE
增加选项控制是否禁用rearrange

### DIFF
--- a/luaecs.c
+++ b/luaecs.c
@@ -365,7 +365,7 @@ static int
 lupdate(lua_State *L) {
 	struct entity_world *w = getW(L);
 	int removed_id = luaL_optinteger(L, 2, ENTITY_REMOVED);
-    int disable_rearrange = lua_toboolean(L, 3);
+	int disable_rearrange = lua_toboolean(L, 3);
 	struct component_pool *removed = &w->c[removed_id];
 	int i;
 	if (removed->n > 0) {

--- a/luaecs.c
+++ b/luaecs.c
@@ -365,6 +365,7 @@ static int
 lupdate(lua_State *L) {
 	struct entity_world *w = getW(L);
 	int removed_id = luaL_optinteger(L, 2, ENTITY_REMOVED);
+    int disable_rearrange = lua_toboolean(L, 3);
 	struct component_pool *removed = &w->c[removed_id];
 	int i;
 	if (removed->n > 0) {
@@ -377,7 +378,7 @@ lupdate(lua_State *L) {
 		removed->n = 0;
 	}
 
-	if (w->max_id > REARRANGE_THRESHOLD) {
+	if (!disable_rearrange && w->max_id > REARRANGE_THRESHOLD) {
 		rearrange(w);
 	}
 


### PR DESCRIPTION
增加选项控制, 可以让业务更灵活的控制是否rearrange

举个例子, 在后台应用时, 可能不需要rearrange, 可以基于非rearrange用法做一些优化.