### PR TITLE
can overide the template value of component

### DIFF
--- a/ecs.lua
+++ b/ecs.lua
@@ -404,6 +404,9 @@ function M:template_instance(eid, temp, obj)
 			break
 		end
 		local id = self:_addcomponent(index, cid)
+		if obj[tname] then 
+			goto continue
+		end
 		local tname = ctx.typeidtoname[cid]
 		local tc = ctx.typenames[tname]
 		if tc.unmarshal then
@@ -415,6 +418,7 @@ function M:template_instance(eid, temp, obj)
 			assert(tc.size > 0, "Missing unmarshal function for lua object")
 			template_methods._template_instance_component(self, cid, id, arg1, arg2)
 		end
+		::continue::
 	end
 	if obj then
 		_new_entity(self, index, obj)

--- a/luaecs.c
+++ b/luaecs.c
@@ -193,7 +193,7 @@ add_component_id_(struct component_pool *pool, int cid, entity_index_t eid) {
 	if (index > 0 && (cmp = ENTITY_INDEX_CMP(pool->id[index-1], eid)) >= 0) {
 		do {
 			if (cmp == 0)
-				return -1;
+				return index - 1;
 			--index;
 		} while (index > 0 && (cmp = ENTITY_INDEX_CMP(pool->id[index-1], eid)) >= 0);
 		// move [index, pool->n) -> [index+1, pool->n]


### PR DESCRIPTION
We use w:template_instance(eid, temp, obj).
Will use obj's component other than temp's component.
Or there is no need to modify the C code.
#28 